### PR TITLE
protoc-gen-object: Fix the bug that inline field is not embdedded

### DIFF
--- a/example/Makefile
+++ b/example/Makefile
@@ -3,7 +3,7 @@ build: pkg/apis/blogv1alpha1/blog_proto_kubeproto.generated.object.go \
 		pkg/apis/blogv1alpha2/blog_proto_kubeproto.generated.object.go \
 		pkg/client/k8s.generated.client.go \
 		pkg/client/testingclient/k8s.generated.testingclient.go \
-		crd/k8s.crd.yaml
+		crd/blog.crd.yaml
 
 .PHONY: pkg/apis/blogv1alpha1/blog_proto_kubeproto.generated.object.go
 pkg/apis/blogv1alpha1/blog_proto_kubeproto.generated.object.go:

--- a/example/crd/blog.crd.yaml
+++ b/example/crd/blog.crd.yaml
@@ -156,6 +156,53 @@ spec:
                   - description
                   type: object
                 type: array
+              editorSelector:
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                             Valid operators are In, NotIn, Exists and DoesNotExist.
+                          enum:
+                          - In
+                          - NotIn
+                          - Exists
+                          - DoesNotExist
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                             the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                             the values array must be empty. This array is replaced during a strategic
+                             merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      - values
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                       map is equivalent to an element of matchExpressions, whose key field is "key", the
+                       operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                  namespace:
+                    type: string
+                type: object
               serviceAccountJSON:
                 properties:
                   key:
@@ -187,6 +234,7 @@ spec:
             - title
             - authorSelector
             - tags
+            - editorSelector
             type: object
           status:
             properties:

--- a/example/pkg/apis/blogv1alpha2/blog.proto
+++ b/example/pkg/apis/blogv1alpha2/blog.proto
@@ -29,6 +29,7 @@ message BlogSpec {
   repeated string   tags                                             = 3;
   repeated Category categories                                       = 4;
   optional k8s.io.api.core.v1.SecretKeySelector service_account_json = 5 [(dev.f110.kubeproto.field) = { go_name: "ServiceAccountJSON", api_field_name: "serviceAccountJSON" }];
+  LabelSelector                                 editor_selector      = 6;
 }
 
 message BlogStatus {
@@ -79,3 +80,8 @@ message Author {
 message AuthorSpec {}
 
 message AuthorStatus {}
+
+message LabelSelector {
+  k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector label_selector   = 1 [(dev.f110.kubeproto.field) = { inline: true }];
+  optional                                           string namespace = 2;
+}

--- a/example/pkg/apis/blogv1alpha2/blog_proto_kubeproto.generated.object.go
+++ b/example/pkg/apis/blogv1alpha2/blog_proto_kubeproto.generated.object.go
@@ -276,6 +276,7 @@ type BlogSpec struct {
 	Tags               []string                  `json:"tags"`
 	Categories         []Category                `json:"categories"`
 	ServiceAccountJSON *corev1.SecretKeySelector `json:"serviceAccountJSON,omitempty"`
+	EditorSelector     LabelSelector             `json:"editorSelector"`
 }
 
 func (in *BlogSpec) DeepCopyInto(out *BlogSpec) {
@@ -298,6 +299,7 @@ func (in *BlogSpec) DeepCopyInto(out *BlogSpec) {
 		*out = new(corev1.SecretKeySelector)
 		(*in).DeepCopyInto(*out)
 	}
+	in.EditorSelector.DeepCopyInto(&out.EditorSelector)
 }
 
 func (in *BlogSpec) DeepCopy() *BlogSpec {
@@ -383,6 +385,25 @@ func (in *Category) DeepCopy() *Category {
 		return nil
 	}
 	out := new(Category)
+	in.DeepCopyInto(out)
+	return out
+}
+
+type LabelSelector struct {
+	metav1.LabelSelector `json:",inline"`
+	Namespace            string `json:"namespace,omitempty"`
+}
+
+func (in *LabelSelector) DeepCopyInto(out *LabelSelector) {
+	*out = *in
+	out.LabelSelector = in.LabelSelector
+}
+
+func (in *LabelSelector) DeepCopy() *LabelSelector {
+	if in == nil {
+		return nil
+	}
+	out := new(LabelSelector)
 	in.DeepCopyInto(out)
 	return out
 }

--- a/internal/definition/message.go
+++ b/internal/definition/message.go
@@ -192,6 +192,7 @@ func NewMessageFromMessageDescriptor(m protoreflect.MessageDescriptor, f protore
 			MessageName: messageName,
 			Description: description,
 			Inline:      inline,
+			Embed:       inline,
 			Optional:    v.HasOptionalKeyword() || v.IsMap(),
 			SubResource: subResource,
 			descriptor:  v,


### PR DESCRIPTION
protoc-gen-object: Fix the bug that inline field is not embdedded

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/f110/kubeproto/pull/11).
* __->__ #11
