### PR TITLE
protoc-gen-object: Support embbedded field with different field and type name

### DIFF
--- a/example/pkg/apis/blogv1alpha2/blog.proto
+++ b/example/pkg/apis/blogv1alpha2/blog.proto
@@ -82,6 +82,6 @@ message AuthorSpec {}
 message AuthorStatus {}
 
 message LabelSelector {
-  k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector label_selector   = 1 [(dev.f110.kubeproto.field) = { inline: true }];
+  k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector pod_selector     = 1 [(dev.f110.kubeproto.field) = { inline: true }];
   optional                                           string namespace = 2;
 }

--- a/internal/k8s/object.go
+++ b/internal/k8s/object.go
@@ -173,7 +173,11 @@ func (g *ObjectGenerator) Generate(out io.Writer) error {
 					continue
 				}
 				if f.Inline {
-					defW.F("out.%s = in.%s", f.Name, f.Name)
+					_, alias, typ := g.lister.ResolveGoType(packageName, f)
+					if alias != "" {
+						typ = strings.TrimPrefix(typ, alias+".")
+					}
+					defW.F("out.%s = in.%s", typ, typ)
 				} else {
 					defW.F("in.%s.DeepCopyInto(&out.%s)", f.Name, f.Name)
 				}


### PR DESCRIPTION
protoc-gen-object: Support embbedded field with different field and type name

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/f110/kubeproto/pull/12).
* __->__ #12
