### PR TITLE
protoc-gen-object: Fix the error if kubeproto_go_package is empty

### DIFF
--- a/internal/k8s/object.go
+++ b/internal/k8s/object.go
@@ -58,7 +58,7 @@ func (g *ObjectGenerator) Generate(out io.Writer) error {
 
 	packageName := fileOpt.GetGoPackage()
 	kubeprotoGoPackage := proto.GetExtension(g.file.Options(), kubeproto.E_KubeprotoGoPackage)
-	if kubeprotoGoPackage != nil {
+	if kubeprotoGoPackage.(string) != "" {
 		packageName = kubeprotoGoPackage.(string)
 	}
 	w.F("package %s", path.Base(packageName))


### PR DESCRIPTION
protoc-gen-object: Fix the error if kubeproto_go_package is empty
