### PR TITLE
protoc-gen-client: Use own metav1 package instead of k8s.io

### DIFF
--- a/example/pkg/client/k8s.generated.client.go
+++ b/example/pkg/client/k8s.generated.client.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -16,6 +16,8 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
+
+	"go.f110.dev/kubeproto/go/apis/metav1"
 
 	"go.f110.dev/kubeproto/example/pkg/apis/blogv1alpha1"
 	"go.f110.dev/kubeproto/example/pkg/apis/blogv1alpha2"
@@ -110,8 +112,8 @@ func (r *restBackend) Get(ctx context.Context, resourceName, kindName, namespace
 
 func (r *restBackend) List(ctx context.Context, resourceName, kindName, namespace string, opts metav1.ListOptions, result runtime.Object) (runtime.Object, error) {
 	var timeout time.Duration
-	if opts.TimeoutSeconds != nil {
-		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
+	if opts.TimeoutSeconds > 0 {
+		timeout = time.Duration(opts.TimeoutSeconds) * time.Second
 	}
 	return result, r.client.Get().
 		Namespace(namespace).
@@ -179,8 +181,8 @@ func (r *restBackend) Delete(ctx context.Context, gvr schema.GroupVersionResourc
 
 func (r *restBackend) Watch(ctx context.Context, gvr schema.GroupVersionResource, namespace string, opts metav1.ListOptions) (watch.Interface, error) {
 	var timeout time.Duration
-	if opts.TimeoutSeconds != nil {
-		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
+	if opts.TimeoutSeconds > 0 {
+		timeout = time.Duration(opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
 	return r.client.Get().
@@ -202,8 +204,8 @@ func (r *restBackend) GetClusterScoped(ctx context.Context, resourceName, kindNa
 
 func (r *restBackend) ListClusterScoped(ctx context.Context, resourceName, kindName string, opts metav1.ListOptions, result runtime.Object) (runtime.Object, error) {
 	var timeout time.Duration
-	if opts.TimeoutSeconds != nil {
-		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
+	if opts.TimeoutSeconds > 0 {
+		timeout = time.Duration(opts.TimeoutSeconds) * time.Second
 	}
 	return result, r.client.Get().
 		Resource(resourceName).
@@ -262,8 +264,8 @@ func (r *restBackend) DeleteClusterScoped(ctx context.Context, gvr schema.GroupV
 
 func (r *restBackend) WatchClusterScoped(ctx context.Context, gvr schema.GroupVersionResource, opts metav1.ListOptions) (watch.Interface, error) {
 	var timeout time.Duration
-	if opts.TimeoutSeconds != nil {
-		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
+	if opts.TimeoutSeconds > 0 {
+		timeout = time.Duration(opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
 	return r.client.Get().
@@ -602,10 +604,10 @@ func (f *BlogV1alpha1Informer) BlogInformer() cache.SharedIndexInformer {
 	return f.cache.Write(&blogv1alpha1.Blog{}, func() cache.SharedIndexInformer {
 		return cache.NewSharedIndexInformer(
 			&cache.ListWatch{
-				ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				ListFunc: func(options k8smetav1.ListOptions) (runtime.Object, error) {
 					return f.client.ListBlog(context.TODO(), metav1.ListOptions{})
 				},
-				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				WatchFunc: func(options k8smetav1.ListOptions) (watch.Interface, error) {
 					return f.client.WatchBlog(context.TODO(), metav1.ListOptions{})
 				},
 			},
@@ -624,10 +626,10 @@ func (f *BlogV1alpha1Informer) PostInformer() cache.SharedIndexInformer {
 	return f.cache.Write(&blogv1alpha1.Post{}, func() cache.SharedIndexInformer {
 		return cache.NewSharedIndexInformer(
 			&cache.ListWatch{
-				ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				ListFunc: func(options k8smetav1.ListOptions) (runtime.Object, error) {
 					return f.client.ListPost(context.TODO(), f.namespace, metav1.ListOptions{})
 				},
-				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				WatchFunc: func(options k8smetav1.ListOptions) (watch.Interface, error) {
 					return f.client.WatchPost(context.TODO(), f.namespace, metav1.ListOptions{})
 				},
 			},
@@ -664,10 +666,10 @@ func (f *BlogV1alpha2Informer) AuthorInformer() cache.SharedIndexInformer {
 	return f.cache.Write(&blogv1alpha2.Author{}, func() cache.SharedIndexInformer {
 		return cache.NewSharedIndexInformer(
 			&cache.ListWatch{
-				ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				ListFunc: func(options k8smetav1.ListOptions) (runtime.Object, error) {
 					return f.client.ListAuthor(context.TODO(), f.namespace, metav1.ListOptions{})
 				},
-				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				WatchFunc: func(options k8smetav1.ListOptions) (watch.Interface, error) {
 					return f.client.WatchAuthor(context.TODO(), f.namespace, metav1.ListOptions{})
 				},
 			},
@@ -686,10 +688,10 @@ func (f *BlogV1alpha2Informer) BlogInformer() cache.SharedIndexInformer {
 	return f.cache.Write(&blogv1alpha2.Blog{}, func() cache.SharedIndexInformer {
 		return cache.NewSharedIndexInformer(
 			&cache.ListWatch{
-				ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				ListFunc: func(options k8smetav1.ListOptions) (runtime.Object, error) {
 					return f.client.ListBlog(context.TODO(), metav1.ListOptions{})
 				},
-				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				WatchFunc: func(options k8smetav1.ListOptions) (watch.Interface, error) {
 					return f.client.WatchBlog(context.TODO(), metav1.ListOptions{})
 				},
 			},
@@ -708,10 +710,10 @@ func (f *BlogV1alpha2Informer) PostInformer() cache.SharedIndexInformer {
 	return f.cache.Write(&blogv1alpha2.Post{}, func() cache.SharedIndexInformer {
 		return cache.NewSharedIndexInformer(
 			&cache.ListWatch{
-				ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				ListFunc: func(options k8smetav1.ListOptions) (runtime.Object, error) {
 					return f.client.ListPost(context.TODO(), f.namespace, metav1.ListOptions{})
 				},
-				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				WatchFunc: func(options k8smetav1.ListOptions) (watch.Interface, error) {
 					return f.client.WatchPost(context.TODO(), f.namespace, metav1.ListOptions{})
 				},
 			},

--- a/example/pkg/client/testingclient/k8s.generated.testingclient.go
+++ b/example/pkg/client/testingclient/k8s.generated.testingclient.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -13,6 +12,7 @@ import (
 	k8stesting "k8s.io/client-go/testing"
 
 	"go.f110.dev/kubeproto/example/pkg/client"
+	"go.f110.dev/kubeproto/go/apis/metav1"
 )
 
 var (

--- a/internal/goparser/parser.go
+++ b/internal/goparser/parser.go
@@ -41,7 +41,7 @@ var preDefinedPackages = []packageInformation{
 	{
 		GoPackage:       "k8s.io/apimachinery/pkg/apis/meta/v1",
 		ProtobufPackage: "k8s.io.apimachinery.pkg.apis.meta.v1",
-		ImportPath:      "k8s.io/apimachinery/pkg/apis/meta/v1",
+		ImportPath:      "go.f110.dev/kubeproto/go/apis/metav1",
 	},
 	{
 		GoPackage:       "k8s.io/apimachinery/pkg/api/resource",
@@ -61,37 +61,37 @@ var preDefinedPackages = []packageInformation{
 	{
 		GoPackage:       "k8s.io/api/core/v1",
 		ProtobufPackage: "k8s.io.api.core.v1",
-		ImportPath:      "k8s.io/api/core/v1",
+		ImportPath:      "go.f110.dev/kubeproto/go/apis/corev1",
 	},
 	{
 		GoPackage:       "k8s.io/api/apps/v1",
 		ProtobufPackage: "k8s.io.api.apps.v1",
-		ImportPath:      "k8s.io/api/apps/v1",
+		ImportPath:      "go.f110.dev/kubeproto/go/apis/appsv1",
 	},
 	{
 		GoPackage:       "k8s.io/api/batch/v1",
 		ProtobufPackage: "k8s.io.api.batch.v1",
-		ImportPath:      "k8s.io/api/batch/v1",
+		ImportPath:      "go.f110.dev/kubeproto/go/apis/batchv1",
 	},
 	{
 		GoPackage:       "k8s.io/api/policy/v1",
 		ProtobufPackage: "k8s.io.api.policy.v1",
-		ImportPath:      "k8s.io/api/policy/v1",
+		ImportPath:      "go.f110.dev/kubeproto/go/apis/policyv1",
 	},
 	{
 		GoPackage:       "k8s.io/api/networking/v1",
 		ProtobufPackage: "k8s.io.api.networking.v1",
-		ImportPath:      "k8s.io/api/networking/v1",
+		ImportPath:      "go.f110.dev/kubeproto/go/apis/networkingv1",
 	},
 	{
 		GoPackage:       "k8s.io/api/authentication/v1",
 		ProtobufPackage: "k8s.io.api.authentication.v1",
-		ImportPath:      "k8s.io/api/authentication/v1",
+		ImportPath:      "go.f110.dev/kubeproto/go/apis/authenticationv1",
 	},
 	{
 		GoPackage:       "k8s.io/api/admission/v1",
 		ProtobufPackage: "k8s.io.api.admission.v1",
-		ImportPath:      "k8s.io/api/admission/v1",
+		ImportPath:      "go.f110.dev/kubeproto/go/apis/admissionv1",
 	},
 	{
 		GoPackage:       "sigs.k8s.io/gateway-api/apis/v1alpha2",

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -232,8 +232,8 @@ func newRestClientGenerator(groupVersions map[string][]*definition.Message) *res
 func (g *restClientGenerator) Import() map[string]string {
 	importPackages := map[string]string{
 		"k8s.io/client-go/rest":                "",
-		"k8s.io/apimachinery/pkg/apis/meta/v1": "metav1",
 		"k8s.io/apimachinery/pkg/watch":        "",
+		"go.f110.dev/kubeproto/go/apis/metav1": "",
 	}
 	for _, v := range g.groupVersions {
 		for _, m := range v {
@@ -266,8 +266,8 @@ func (r *restBackend) Get(ctx context.Context, resourceName, kindName, namespace
 
 func (r *restBackend) List(ctx context.Context, resourceName, kindName, namespace string, opts metav1.ListOptions, result runtime.Object) (runtime.Object, error) {
 	var timeout time.Duration
-	if opts.TimeoutSeconds != nil {
-		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
+	if opts.TimeoutSeconds > 0 {
+		timeout = time.Duration(opts.TimeoutSeconds) * time.Second
 	}
 	return result, r.client.Get().
 		Namespace(namespace).
@@ -335,8 +335,8 @@ func (r *restBackend) Delete(ctx context.Context, gvr schema.GroupVersionResourc
 
 func (r *restBackend) Watch(ctx context.Context, gvr schema.GroupVersionResource, namespace string, opts metav1.ListOptions) (watch.Interface, error) {
 	var timeout time.Duration
-	if opts.TimeoutSeconds != nil {
-		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
+	if opts.TimeoutSeconds > 0 {
+		timeout = time.Duration(opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
 	return r.client.Get().
@@ -358,8 +358,8 @@ func (r *restBackend) GetClusterScoped(ctx context.Context, resourceName, kindNa
 
 func (r *restBackend) ListClusterScoped(ctx context.Context, resourceName, kindName string, opts metav1.ListOptions, result runtime.Object) (runtime.Object, error) {
 	var timeout time.Duration
-	if opts.TimeoutSeconds != nil {
-		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
+	if opts.TimeoutSeconds > 0 {
+		timeout = time.Duration(opts.TimeoutSeconds) * time.Second
 	}
 	return result, r.client.Get().
 		Resource(resourceName).
@@ -418,8 +418,8 @@ func (r *restBackend) DeleteClusterScoped(ctx context.Context, gvr schema.GroupV
 
 func (r *restBackend) WatchClusterScoped(ctx context.Context, gvr schema.GroupVersionResource, opts metav1.ListOptions) (watch.Interface, error) {
 	var timeout time.Duration
-	if opts.TimeoutSeconds != nil {
-		timeout = time.Duration(*opts.TimeoutSeconds) * time.Second
+	if opts.TimeoutSeconds > 0 {
+		timeout = time.Duration(opts.TimeoutSeconds) * time.Second
 	}
 	opts.Watch = true
 	return r.client.Get().
@@ -595,11 +595,12 @@ func (g *informerGenerator) Import() map[string]string {
 		"context":                                "",
 		"time":                                   "",
 		"k8s.io/client-go/rest":                  "",
-		"k8s.io/apimachinery/pkg/apis/meta/v1":   "metav1",
 		"k8s.io/apimachinery/pkg/watch":          "",
 		"k8s.io/apimachinery/pkg/runtime":        "",
 		"k8s.io/apimachinery/pkg/runtime/schema": "",
 		"k8s.io/client-go/tools/cache":           "",
+		"go.f110.dev/kubeproto/go/apis/metav1":   "",
+		"k8s.io/apimachinery/pkg/apis/meta/v1":   "k8smetav1",
 	}
 	for _, v := range g.groupVersions {
 		for _, m := range v {
@@ -745,10 +746,10 @@ func (g *informerGenerator) WriteTo(writer *codegeneration.Writer, fqdn bool) er
 			if m.Scope == definition.ScopeTypeCluster {
 				writer.F("return cache.NewSharedIndexInformer(")
 				writer.F("&cache.ListWatch{")
-				writer.F("ListFunc: func (options metav1.ListOptions) (runtime.Object, error){")
+				writer.F("ListFunc: func (options k8smetav1.ListOptions) (runtime.Object, error){")
 				writer.F("return f.client.List%s(context.TODO(), metav1.ListOptions{})", m.ShortName)
 				writer.F("},") // end of ListFunc
-				writer.F("WatchFunc: func (options metav1.ListOptions) (watch.Interface, error){")
+				writer.F("WatchFunc: func (options k8smetav1.ListOptions) (watch.Interface, error){")
 				writer.F("return f.client.Watch%s(context.TODO(), metav1.ListOptions{})", m.ShortName)
 				writer.F("},") // end of WatchFunc
 				writer.F("},")
@@ -759,10 +760,10 @@ func (g *informerGenerator) WriteTo(writer *codegeneration.Writer, fqdn bool) er
 			} else {
 				writer.F("return cache.NewSharedIndexInformer(")
 				writer.F("&cache.ListWatch{")
-				writer.F("ListFunc: func (options metav1.ListOptions) (runtime.Object, error){")
+				writer.F("ListFunc: func (options k8smetav1.ListOptions) (runtime.Object, error){")
 				writer.F("return f.client.List%s(context.TODO(), f.namespace, metav1.ListOptions{})", m.ShortName)
 				writer.F("},") // end of ListFunc
-				writer.F("WatchFunc: func (options metav1.ListOptions) (watch.Interface, error){")
+				writer.F("WatchFunc: func (options k8smetav1.ListOptions) (watch.Interface, error){")
 				writer.F("return f.client.Watch%s(context.TODO(), f.namespace, metav1.ListOptions{})", m.ShortName)
 				writer.F("},") // end of WatchFunc
 				writer.F("},")

--- a/internal/k8s/testingclient.go
+++ b/internal/k8s/testingclient.go
@@ -98,13 +98,13 @@ func newRestFakeClientGenerator(groupVersions map[string][]*definition.Message, 
 func (g *restFakeClientGenerator) Import() map[string]string {
 	importPackages := map[string]string{
 		"k8s.io/apimachinery/pkg/api/meta":           "",
-		"k8s.io/apimachinery/pkg/apis/meta/v1":       "metav1",
 		"k8s.io/apimachinery/pkg/watch":              "",
 		"k8s.io/apimachinery/pkg/labels":             "",
 		"k8s.io/apimachinery/pkg/runtime":            "",
 		"k8s.io/apimachinery/pkg/runtime/schema":     "",
 		"k8s.io/apimachinery/pkg/runtime/serializer": "",
 		"k8s.io/client-go/testing":                   "k8stesting",
+		"go.f110.dev/kubeproto/go/apis/metav1":       "",
 		g.clientPath:                                 "",
 	}
 


### PR DESCRIPTION
protoc-gen-client: Use own metav1 package instead of k8s.io
