### PR TITLE
gen-go-to-protobuf: Support sub resource update

### DIFF
--- a/go/k8sclient/go_client.generated.client.go
+++ b/go/k8sclient/go_client.generated.client.go
@@ -757,6 +757,14 @@ func (c *CoreV1) UpdateNamespace(ctx context.Context, v *corev1.Namespace, opts 
 	return result.(*corev1.Namespace), nil
 }
 
+func (c *CoreV1) UpdateStatusNamespace(ctx context.Context, v *corev1.Namespace, opts metav1.UpdateOptions) (*corev1.Namespace, error) {
+	result, err := c.backend.UpdateStatusClusterScoped(ctx, "namespaces", "Namespace", v, opts, &corev1.Namespace{})
+	if err != nil {
+		return nil, err
+	}
+	return result.(*corev1.Namespace), nil
+}
+
 func (c *CoreV1) DeleteNamespace(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.backend.DeleteClusterScoped(ctx, schema.GroupVersionResource{Group: ".", Version: "v1", Resource: "namespaces"}, name, opts)
 }
@@ -791,6 +799,14 @@ func (c *CoreV1) CreateNode(ctx context.Context, v *corev1.Node, opts metav1.Cre
 
 func (c *CoreV1) UpdateNode(ctx context.Context, v *corev1.Node, opts metav1.UpdateOptions) (*corev1.Node, error) {
 	result, err := c.backend.UpdateClusterScoped(ctx, "nodes", "Node", v, opts, &corev1.Node{})
+	if err != nil {
+		return nil, err
+	}
+	return result.(*corev1.Node), nil
+}
+
+func (c *CoreV1) UpdateStatusNode(ctx context.Context, v *corev1.Node, opts metav1.UpdateOptions) (*corev1.Node, error) {
+	result, err := c.backend.UpdateStatusClusterScoped(ctx, "nodes", "Node", v, opts, &corev1.Node{})
 	if err != nil {
 		return nil, err
 	}
@@ -837,6 +853,14 @@ func (c *CoreV1) UpdatePersistentVolume(ctx context.Context, v *corev1.Persisten
 	return result.(*corev1.PersistentVolume), nil
 }
 
+func (c *CoreV1) UpdateStatusPersistentVolume(ctx context.Context, v *corev1.PersistentVolume, opts metav1.UpdateOptions) (*corev1.PersistentVolume, error) {
+	result, err := c.backend.UpdateStatusClusterScoped(ctx, "persistentvolumes", "PersistentVolume", v, opts, &corev1.PersistentVolume{})
+	if err != nil {
+		return nil, err
+	}
+	return result.(*corev1.PersistentVolume), nil
+}
+
 func (c *CoreV1) DeletePersistentVolume(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.backend.DeleteClusterScoped(ctx, schema.GroupVersionResource{Group: ".", Version: "v1", Resource: "persistentvolumes"}, name, opts)
 }
@@ -871,6 +895,14 @@ func (c *CoreV1) CreatePersistentVolumeClaim(ctx context.Context, v *corev1.Pers
 
 func (c *CoreV1) UpdatePersistentVolumeClaim(ctx context.Context, v *corev1.PersistentVolumeClaim, opts metav1.UpdateOptions) (*corev1.PersistentVolumeClaim, error) {
 	result, err := c.backend.Update(ctx, "persistentvolumeclaims", "PersistentVolumeClaim", v, opts, &corev1.PersistentVolumeClaim{})
+	if err != nil {
+		return nil, err
+	}
+	return result.(*corev1.PersistentVolumeClaim), nil
+}
+
+func (c *CoreV1) UpdateStatusPersistentVolumeClaim(ctx context.Context, v *corev1.PersistentVolumeClaim, opts metav1.UpdateOptions) (*corev1.PersistentVolumeClaim, error) {
+	result, err := c.backend.UpdateStatus(ctx, "persistentvolumeclaims", "PersistentVolumeClaim", v, opts, &corev1.PersistentVolumeClaim{})
 	if err != nil {
 		return nil, err
 	}
@@ -917,6 +949,14 @@ func (c *CoreV1) UpdatePod(ctx context.Context, v *corev1.Pod, opts metav1.Updat
 	return result.(*corev1.Pod), nil
 }
 
+func (c *CoreV1) UpdateStatusPod(ctx context.Context, v *corev1.Pod, opts metav1.UpdateOptions) (*corev1.Pod, error) {
+	result, err := c.backend.UpdateStatus(ctx, "pods", "Pod", v, opts, &corev1.Pod{})
+	if err != nil {
+		return nil, err
+	}
+	return result.(*corev1.Pod), nil
+}
+
 func (c *CoreV1) DeletePod(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error {
 	return c.backend.Delete(ctx, schema.GroupVersionResource{Group: ".", Version: "v1", Resource: "pods"}, namespace, name, opts)
 }
@@ -951,6 +991,14 @@ func (c *CoreV1) CreatePodStatusResult(ctx context.Context, v *corev1.PodStatusR
 
 func (c *CoreV1) UpdatePodStatusResult(ctx context.Context, v *corev1.PodStatusResult, opts metav1.UpdateOptions) (*corev1.PodStatusResult, error) {
 	result, err := c.backend.Update(ctx, "podstatusresults", "PodStatusResult", v, opts, &corev1.PodStatusResult{})
+	if err != nil {
+		return nil, err
+	}
+	return result.(*corev1.PodStatusResult), nil
+}
+
+func (c *CoreV1) UpdateStatusPodStatusResult(ctx context.Context, v *corev1.PodStatusResult, opts metav1.UpdateOptions) (*corev1.PodStatusResult, error) {
+	result, err := c.backend.UpdateStatus(ctx, "podstatusresults", "PodStatusResult", v, opts, &corev1.PodStatusResult{})
 	if err != nil {
 		return nil, err
 	}
@@ -1077,6 +1125,14 @@ func (c *CoreV1) UpdateReplicationController(ctx context.Context, v *corev1.Repl
 	return result.(*corev1.ReplicationController), nil
 }
 
+func (c *CoreV1) UpdateStatusReplicationController(ctx context.Context, v *corev1.ReplicationController, opts metav1.UpdateOptions) (*corev1.ReplicationController, error) {
+	result, err := c.backend.UpdateStatus(ctx, "replicationcontrollers", "ReplicationController", v, opts, &corev1.ReplicationController{})
+	if err != nil {
+		return nil, err
+	}
+	return result.(*corev1.ReplicationController), nil
+}
+
 func (c *CoreV1) DeleteReplicationController(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error {
 	return c.backend.Delete(ctx, schema.GroupVersionResource{Group: ".", Version: "v1", Resource: "replicationcontrollers"}, namespace, name, opts)
 }
@@ -1111,6 +1167,14 @@ func (c *CoreV1) CreateResourceQuota(ctx context.Context, v *corev1.ResourceQuot
 
 func (c *CoreV1) UpdateResourceQuota(ctx context.Context, v *corev1.ResourceQuota, opts metav1.UpdateOptions) (*corev1.ResourceQuota, error) {
 	result, err := c.backend.Update(ctx, "resourcequotas", "ResourceQuota", v, opts, &corev1.ResourceQuota{})
+	if err != nil {
+		return nil, err
+	}
+	return result.(*corev1.ResourceQuota), nil
+}
+
+func (c *CoreV1) UpdateStatusResourceQuota(ctx context.Context, v *corev1.ResourceQuota, opts metav1.UpdateOptions) (*corev1.ResourceQuota, error) {
+	result, err := c.backend.UpdateStatus(ctx, "resourcequotas", "ResourceQuota", v, opts, &corev1.ResourceQuota{})
 	if err != nil {
 		return nil, err
 	}
@@ -1191,6 +1255,14 @@ func (c *CoreV1) CreateService(ctx context.Context, v *corev1.Service, opts meta
 
 func (c *CoreV1) UpdateService(ctx context.Context, v *corev1.Service, opts metav1.UpdateOptions) (*corev1.Service, error) {
 	result, err := c.backend.Update(ctx, "services", "Service", v, opts, &corev1.Service{})
+	if err != nil {
+		return nil, err
+	}
+	return result.(*corev1.Service), nil
+}
+
+func (c *CoreV1) UpdateStatusService(ctx context.Context, v *corev1.Service, opts metav1.UpdateOptions) (*corev1.Service, error) {
+	result, err := c.backend.UpdateStatus(ctx, "services", "Service", v, opts, &corev1.Service{})
 	if err != nil {
 		return nil, err
 	}
@@ -1413,6 +1485,14 @@ func (c *AppsV1) UpdateCronJob(ctx context.Context, v *batchv1.CronJob, opts met
 	return result.(*batchv1.CronJob), nil
 }
 
+func (c *AppsV1) UpdateStatusCronJob(ctx context.Context, v *batchv1.CronJob, opts metav1.UpdateOptions) (*batchv1.CronJob, error) {
+	result, err := c.backend.UpdateStatus(ctx, "cronjobs", "CronJob", v, opts, &batchv1.CronJob{})
+	if err != nil {
+		return nil, err
+	}
+	return result.(*batchv1.CronJob), nil
+}
+
 func (c *AppsV1) DeleteCronJob(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error {
 	return c.backend.Delete(ctx, schema.GroupVersionResource{Group: ".apps", Version: "v1", Resource: "cronjobs"}, namespace, name, opts)
 }
@@ -1447,6 +1527,14 @@ func (c *AppsV1) CreateDaemonSet(ctx context.Context, v *appsv1.DaemonSet, opts 
 
 func (c *AppsV1) UpdateDaemonSet(ctx context.Context, v *appsv1.DaemonSet, opts metav1.UpdateOptions) (*appsv1.DaemonSet, error) {
 	result, err := c.backend.Update(ctx, "daemonsets", "DaemonSet", v, opts, &appsv1.DaemonSet{})
+	if err != nil {
+		return nil, err
+	}
+	return result.(*appsv1.DaemonSet), nil
+}
+
+func (c *AppsV1) UpdateStatusDaemonSet(ctx context.Context, v *appsv1.DaemonSet, opts metav1.UpdateOptions) (*appsv1.DaemonSet, error) {
+	result, err := c.backend.UpdateStatus(ctx, "daemonsets", "DaemonSet", v, opts, &appsv1.DaemonSet{})
 	if err != nil {
 		return nil, err
 	}
@@ -1493,6 +1581,14 @@ func (c *AppsV1) UpdateDeployment(ctx context.Context, v *appsv1.Deployment, opt
 	return result.(*appsv1.Deployment), nil
 }
 
+func (c *AppsV1) UpdateStatusDeployment(ctx context.Context, v *appsv1.Deployment, opts metav1.UpdateOptions) (*appsv1.Deployment, error) {
+	result, err := c.backend.UpdateStatus(ctx, "deployments", "Deployment", v, opts, &appsv1.Deployment{})
+	if err != nil {
+		return nil, err
+	}
+	return result.(*appsv1.Deployment), nil
+}
+
 func (c *AppsV1) DeleteDeployment(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error {
 	return c.backend.Delete(ctx, schema.GroupVersionResource{Group: ".apps", Version: "v1", Resource: "deployments"}, namespace, name, opts)
 }
@@ -1527,6 +1623,14 @@ func (c *AppsV1) CreateJob(ctx context.Context, v *batchv1.Job, opts metav1.Crea
 
 func (c *AppsV1) UpdateJob(ctx context.Context, v *batchv1.Job, opts metav1.UpdateOptions) (*batchv1.Job, error) {
 	result, err := c.backend.Update(ctx, "jobs", "Job", v, opts, &batchv1.Job{})
+	if err != nil {
+		return nil, err
+	}
+	return result.(*batchv1.Job), nil
+}
+
+func (c *AppsV1) UpdateStatusJob(ctx context.Context, v *batchv1.Job, opts metav1.UpdateOptions) (*batchv1.Job, error) {
+	result, err := c.backend.UpdateStatus(ctx, "jobs", "Job", v, opts, &batchv1.Job{})
 	if err != nil {
 		return nil, err
 	}
@@ -1573,6 +1677,14 @@ func (c *AppsV1) UpdateReplicaSet(ctx context.Context, v *appsv1.ReplicaSet, opt
 	return result.(*appsv1.ReplicaSet), nil
 }
 
+func (c *AppsV1) UpdateStatusReplicaSet(ctx context.Context, v *appsv1.ReplicaSet, opts metav1.UpdateOptions) (*appsv1.ReplicaSet, error) {
+	result, err := c.backend.UpdateStatus(ctx, "replicasets", "ReplicaSet", v, opts, &appsv1.ReplicaSet{})
+	if err != nil {
+		return nil, err
+	}
+	return result.(*appsv1.ReplicaSet), nil
+}
+
 func (c *AppsV1) DeleteReplicaSet(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error {
 	return c.backend.Delete(ctx, schema.GroupVersionResource{Group: ".apps", Version: "v1", Resource: "replicasets"}, namespace, name, opts)
 }
@@ -1607,6 +1719,14 @@ func (c *AppsV1) CreateStatefulSet(ctx context.Context, v *appsv1.StatefulSet, o
 
 func (c *AppsV1) UpdateStatefulSet(ctx context.Context, v *appsv1.StatefulSet, opts metav1.UpdateOptions) (*appsv1.StatefulSet, error) {
 	result, err := c.backend.Update(ctx, "statefulsets", "StatefulSet", v, opts, &appsv1.StatefulSet{})
+	if err != nil {
+		return nil, err
+	}
+	return result.(*appsv1.StatefulSet), nil
+}
+
+func (c *AppsV1) UpdateStatusStatefulSet(ctx context.Context, v *appsv1.StatefulSet, opts metav1.UpdateOptions) (*appsv1.StatefulSet, error) {
+	result, err := c.backend.UpdateStatus(ctx, "statefulsets", "StatefulSet", v, opts, &appsv1.StatefulSet{})
 	if err != nil {
 		return nil, err
 	}
@@ -1661,6 +1781,14 @@ func (c *AuthenticationK8sIoV1) UpdateTokenRequest(ctx context.Context, v *authe
 	return result.(*authenticationv1.TokenRequest), nil
 }
 
+func (c *AuthenticationK8sIoV1) UpdateStatusTokenRequest(ctx context.Context, v *authenticationv1.TokenRequest, opts metav1.UpdateOptions) (*authenticationv1.TokenRequest, error) {
+	result, err := c.backend.UpdateStatus(ctx, "tokenrequests", "TokenRequest", v, opts, &authenticationv1.TokenRequest{})
+	if err != nil {
+		return nil, err
+	}
+	return result.(*authenticationv1.TokenRequest), nil
+}
+
 func (c *AuthenticationK8sIoV1) DeleteTokenRequest(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error {
 	return c.backend.Delete(ctx, schema.GroupVersionResource{Group: ".authentication.k8s.io", Version: "v1", Resource: "tokenrequests"}, namespace, name, opts)
 }
@@ -1695,6 +1823,14 @@ func (c *AuthenticationK8sIoV1) CreateTokenReview(ctx context.Context, v *authen
 
 func (c *AuthenticationK8sIoV1) UpdateTokenReview(ctx context.Context, v *authenticationv1.TokenReview, opts metav1.UpdateOptions) (*authenticationv1.TokenReview, error) {
 	result, err := c.backend.UpdateClusterScoped(ctx, "tokenreviews", "TokenReview", v, opts, &authenticationv1.TokenReview{})
+	if err != nil {
+		return nil, err
+	}
+	return result.(*authenticationv1.TokenReview), nil
+}
+
+func (c *AuthenticationK8sIoV1) UpdateStatusTokenReview(ctx context.Context, v *authenticationv1.TokenReview, opts metav1.UpdateOptions) (*authenticationv1.TokenReview, error) {
+	result, err := c.backend.UpdateStatusClusterScoped(ctx, "tokenreviews", "TokenReview", v, opts, &authenticationv1.TokenReview{})
 	if err != nil {
 		return nil, err
 	}
@@ -1749,6 +1885,14 @@ func (c *AuthorizationK8sIoV1) UpdateLocalSubjectAccessReview(ctx context.Contex
 	return result.(*authorizationv1.LocalSubjectAccessReview), nil
 }
 
+func (c *AuthorizationK8sIoV1) UpdateStatusLocalSubjectAccessReview(ctx context.Context, v *authorizationv1.LocalSubjectAccessReview, opts metav1.UpdateOptions) (*authorizationv1.LocalSubjectAccessReview, error) {
+	result, err := c.backend.UpdateStatus(ctx, "localsubjectaccessreviews", "LocalSubjectAccessReview", v, opts, &authorizationv1.LocalSubjectAccessReview{})
+	if err != nil {
+		return nil, err
+	}
+	return result.(*authorizationv1.LocalSubjectAccessReview), nil
+}
+
 func (c *AuthorizationK8sIoV1) DeleteLocalSubjectAccessReview(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error {
 	return c.backend.Delete(ctx, schema.GroupVersionResource{Group: ".authorization.k8s.io", Version: "v1", Resource: "localsubjectaccessreviews"}, namespace, name, opts)
 }
@@ -1783,6 +1927,14 @@ func (c *AuthorizationK8sIoV1) CreateSelfSubjectAccessReview(ctx context.Context
 
 func (c *AuthorizationK8sIoV1) UpdateSelfSubjectAccessReview(ctx context.Context, v *authorizationv1.SelfSubjectAccessReview, opts metav1.UpdateOptions) (*authorizationv1.SelfSubjectAccessReview, error) {
 	result, err := c.backend.UpdateClusterScoped(ctx, "selfsubjectaccessreviews", "SelfSubjectAccessReview", v, opts, &authorizationv1.SelfSubjectAccessReview{})
+	if err != nil {
+		return nil, err
+	}
+	return result.(*authorizationv1.SelfSubjectAccessReview), nil
+}
+
+func (c *AuthorizationK8sIoV1) UpdateStatusSelfSubjectAccessReview(ctx context.Context, v *authorizationv1.SelfSubjectAccessReview, opts metav1.UpdateOptions) (*authorizationv1.SelfSubjectAccessReview, error) {
+	result, err := c.backend.UpdateStatusClusterScoped(ctx, "selfsubjectaccessreviews", "SelfSubjectAccessReview", v, opts, &authorizationv1.SelfSubjectAccessReview{})
 	if err != nil {
 		return nil, err
 	}
@@ -1829,6 +1981,14 @@ func (c *AuthorizationK8sIoV1) UpdateSelfSubjectRulesReview(ctx context.Context,
 	return result.(*authorizationv1.SelfSubjectRulesReview), nil
 }
 
+func (c *AuthorizationK8sIoV1) UpdateStatusSelfSubjectRulesReview(ctx context.Context, v *authorizationv1.SelfSubjectRulesReview, opts metav1.UpdateOptions) (*authorizationv1.SelfSubjectRulesReview, error) {
+	result, err := c.backend.UpdateStatusClusterScoped(ctx, "selfsubjectrulesreviews", "SelfSubjectRulesReview", v, opts, &authorizationv1.SelfSubjectRulesReview{})
+	if err != nil {
+		return nil, err
+	}
+	return result.(*authorizationv1.SelfSubjectRulesReview), nil
+}
+
 func (c *AuthorizationK8sIoV1) DeleteSelfSubjectRulesReview(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.backend.DeleteClusterScoped(ctx, schema.GroupVersionResource{Group: ".authorization.k8s.io", Version: "v1", Resource: "selfsubjectrulesreviews"}, name, opts)
 }
@@ -1863,6 +2023,14 @@ func (c *AuthorizationK8sIoV1) CreateSubjectAccessReview(ctx context.Context, v 
 
 func (c *AuthorizationK8sIoV1) UpdateSubjectAccessReview(ctx context.Context, v *authorizationv1.SubjectAccessReview, opts metav1.UpdateOptions) (*authorizationv1.SubjectAccessReview, error) {
 	result, err := c.backend.UpdateClusterScoped(ctx, "subjectaccessreviews", "SubjectAccessReview", v, opts, &authorizationv1.SubjectAccessReview{})
+	if err != nil {
+		return nil, err
+	}
+	return result.(*authorizationv1.SubjectAccessReview), nil
+}
+
+func (c *AuthorizationK8sIoV1) UpdateStatusSubjectAccessReview(ctx context.Context, v *authorizationv1.SubjectAccessReview, opts metav1.UpdateOptions) (*authorizationv1.SubjectAccessReview, error) {
+	result, err := c.backend.UpdateStatusClusterScoped(ctx, "subjectaccessreviews", "SubjectAccessReview", v, opts, &authorizationv1.SubjectAccessReview{})
 	if err != nil {
 		return nil, err
 	}
@@ -1917,6 +2085,14 @@ func (c *AutoscalingV1) UpdateHorizontalPodAutoscaler(ctx context.Context, v *au
 	return result.(*autoscalingv1.HorizontalPodAutoscaler), nil
 }
 
+func (c *AutoscalingV1) UpdateStatusHorizontalPodAutoscaler(ctx context.Context, v *autoscalingv1.HorizontalPodAutoscaler, opts metav1.UpdateOptions) (*autoscalingv1.HorizontalPodAutoscaler, error) {
+	result, err := c.backend.UpdateStatus(ctx, "horizontalpodautoscalers", "HorizontalPodAutoscaler", v, opts, &autoscalingv1.HorizontalPodAutoscaler{})
+	if err != nil {
+		return nil, err
+	}
+	return result.(*autoscalingv1.HorizontalPodAutoscaler), nil
+}
+
 func (c *AutoscalingV1) DeleteHorizontalPodAutoscaler(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error {
 	return c.backend.Delete(ctx, schema.GroupVersionResource{Group: ".autoscaling", Version: "v1", Resource: "horizontalpodautoscalers"}, namespace, name, opts)
 }
@@ -1951,6 +2127,14 @@ func (c *AutoscalingV1) CreateScale(ctx context.Context, v *autoscalingv1.Scale,
 
 func (c *AutoscalingV1) UpdateScale(ctx context.Context, v *autoscalingv1.Scale, opts metav1.UpdateOptions) (*autoscalingv1.Scale, error) {
 	result, err := c.backend.Update(ctx, "scales", "Scale", v, opts, &autoscalingv1.Scale{})
+	if err != nil {
+		return nil, err
+	}
+	return result.(*autoscalingv1.Scale), nil
+}
+
+func (c *AutoscalingV1) UpdateStatusScale(ctx context.Context, v *autoscalingv1.Scale, opts metav1.UpdateOptions) (*autoscalingv1.Scale, error) {
+	result, err := c.backend.UpdateStatus(ctx, "scales", "Scale", v, opts, &autoscalingv1.Scale{})
 	if err != nil {
 		return nil, err
 	}
@@ -2005,6 +2189,14 @@ func (c *AutoscalingV2) UpdateHorizontalPodAutoscaler(ctx context.Context, v *au
 	return result.(*autoscalingv2.HorizontalPodAutoscaler), nil
 }
 
+func (c *AutoscalingV2) UpdateStatusHorizontalPodAutoscaler(ctx context.Context, v *autoscalingv2.HorizontalPodAutoscaler, opts metav1.UpdateOptions) (*autoscalingv2.HorizontalPodAutoscaler, error) {
+	result, err := c.backend.UpdateStatus(ctx, "horizontalpodautoscalers", "HorizontalPodAutoscaler", v, opts, &autoscalingv2.HorizontalPodAutoscaler{})
+	if err != nil {
+		return nil, err
+	}
+	return result.(*autoscalingv2.HorizontalPodAutoscaler), nil
+}
+
 func (c *AutoscalingV2) DeleteHorizontalPodAutoscaler(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error {
 	return c.backend.Delete(ctx, schema.GroupVersionResource{Group: ".autoscaling", Version: "v2", Resource: "horizontalpodautoscalers"}, namespace, name, opts)
 }
@@ -2047,6 +2239,14 @@ func (c *CertificatesK8sIoV1) CreateCertificateSigningRequest(ctx context.Contex
 
 func (c *CertificatesK8sIoV1) UpdateCertificateSigningRequest(ctx context.Context, v *certificatesv1.CertificateSigningRequest, opts metav1.UpdateOptions) (*certificatesv1.CertificateSigningRequest, error) {
 	result, err := c.backend.UpdateClusterScoped(ctx, "certificatesigningrequests", "CertificateSigningRequest", v, opts, &certificatesv1.CertificateSigningRequest{})
+	if err != nil {
+		return nil, err
+	}
+	return result.(*certificatesv1.CertificateSigningRequest), nil
+}
+
+func (c *CertificatesK8sIoV1) UpdateStatusCertificateSigningRequest(ctx context.Context, v *certificatesv1.CertificateSigningRequest, opts metav1.UpdateOptions) (*certificatesv1.CertificateSigningRequest, error) {
+	result, err := c.backend.UpdateStatusClusterScoped(ctx, "certificatesigningrequests", "CertificateSigningRequest", v, opts, &certificatesv1.CertificateSigningRequest{})
 	if err != nil {
 		return nil, err
 	}
@@ -2245,6 +2445,14 @@ func (c *NetworkingK8sIoV1) UpdateIngress(ctx context.Context, v *networkingv1.I
 	return result.(*networkingv1.Ingress), nil
 }
 
+func (c *NetworkingK8sIoV1) UpdateStatusIngress(ctx context.Context, v *networkingv1.Ingress, opts metav1.UpdateOptions) (*networkingv1.Ingress, error) {
+	result, err := c.backend.UpdateStatus(ctx, "ingresses", "Ingress", v, opts, &networkingv1.Ingress{})
+	if err != nil {
+		return nil, err
+	}
+	return result.(*networkingv1.Ingress), nil
+}
+
 func (c *NetworkingK8sIoV1) DeleteIngress(ctx context.Context, namespace, name string, opts metav1.DeleteOptions) error {
 	return c.backend.Delete(ctx, schema.GroupVersionResource{Group: ".networking.k8s.io", Version: "v1", Resource: "ingresses"}, namespace, name, opts)
 }
@@ -2319,6 +2527,14 @@ func (c *NetworkingK8sIoV1) CreateNetworkPolicy(ctx context.Context, v *networki
 
 func (c *NetworkingK8sIoV1) UpdateNetworkPolicy(ctx context.Context, v *networkingv1.NetworkPolicy, opts metav1.UpdateOptions) (*networkingv1.NetworkPolicy, error) {
 	result, err := c.backend.Update(ctx, "networkpolicies", "NetworkPolicy", v, opts, &networkingv1.NetworkPolicy{})
+	if err != nil {
+		return nil, err
+	}
+	return result.(*networkingv1.NetworkPolicy), nil
+}
+
+func (c *NetworkingK8sIoV1) UpdateStatusNetworkPolicy(ctx context.Context, v *networkingv1.NetworkPolicy, opts metav1.UpdateOptions) (*networkingv1.NetworkPolicy, error) {
+	result, err := c.backend.UpdateStatus(ctx, "networkpolicies", "NetworkPolicy", v, opts, &networkingv1.NetworkPolicy{})
 	if err != nil {
 		return nil, err
 	}
@@ -2407,6 +2623,14 @@ func (c *PolicyV1) CreatePodDisruptionBudget(ctx context.Context, v *policyv1.Po
 
 func (c *PolicyV1) UpdatePodDisruptionBudget(ctx context.Context, v *policyv1.PodDisruptionBudget, opts metav1.UpdateOptions) (*policyv1.PodDisruptionBudget, error) {
 	result, err := c.backend.Update(ctx, "poddisruptionbudgets", "PodDisruptionBudget", v, opts, &policyv1.PodDisruptionBudget{})
+	if err != nil {
+		return nil, err
+	}
+	return result.(*policyv1.PodDisruptionBudget), nil
+}
+
+func (c *PolicyV1) UpdateStatusPodDisruptionBudget(ctx context.Context, v *policyv1.PodDisruptionBudget, opts metav1.UpdateOptions) (*policyv1.PodDisruptionBudget, error) {
+	result, err := c.backend.UpdateStatus(ctx, "poddisruptionbudgets", "PodDisruptionBudget", v, opts, &policyv1.PodDisruptionBudget{})
 	if err != nil {
 		return nil, err
 	}
@@ -2831,6 +3055,14 @@ func (c *StorageK8sIoV1) CreateVolumeAttachment(ctx context.Context, v *storagev
 
 func (c *StorageK8sIoV1) UpdateVolumeAttachment(ctx context.Context, v *storagev1.VolumeAttachment, opts metav1.UpdateOptions) (*storagev1.VolumeAttachment, error) {
 	result, err := c.backend.UpdateClusterScoped(ctx, "volumeattachments", "VolumeAttachment", v, opts, &storagev1.VolumeAttachment{})
+	if err != nil {
+		return nil, err
+	}
+	return result.(*storagev1.VolumeAttachment), nil
+}
+
+func (c *StorageK8sIoV1) UpdateStatusVolumeAttachment(ctx context.Context, v *storagev1.VolumeAttachment, opts metav1.UpdateOptions) (*storagev1.VolumeAttachment, error) {
+	result, err := c.backend.UpdateStatusClusterScoped(ctx, "volumeattachments", "VolumeAttachment", v, opts, &storagev1.VolumeAttachment{})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/goparser/parser.go
+++ b/internal/goparser/parser.go
@@ -465,6 +465,9 @@ func (g *Generator) WriteFile(outputFilePath string) error {
 			if f.APIFieldName != "" {
 				w.Fn("api_field_name: %q, ", f.APIFieldName)
 			}
+			if f.SubResource {
+				w.Fn("sub_resource: true, ")
+			}
 			w.Fn("inline: %v}];", f.Inline)
 			w.F("")
 		}
@@ -611,6 +614,7 @@ func (g *Generator) structToProtobufMessage(v *ast.GenDecl, comment *ast.Comment
 		Name:        typeSpec.Name.String(),
 		UseFieldsOf: useFieldsOf,
 	}
+	var isExistStatusField bool
 	i := 1
 	for _, f := range typeSpec.Type.(*ast.StructType).Fields.List {
 		var name string
@@ -629,6 +633,9 @@ func (g *Generator) structToProtobufMessage(v *ast.GenDecl, comment *ast.Comment
 		if unicode.IsLower(rune(name[0])) {
 			// Private field is ignored
 			continue
+		}
+		if name == "Status" {
+			isExistStatusField = true
 		}
 
 		var inline, optional bool
@@ -729,6 +736,9 @@ func (g *Generator) structToProtobufMessage(v *ast.GenDecl, comment *ast.Comment
 			case "type_meta", "object_meta":
 			default:
 				fields = append(fields, f)
+			}
+			if isExistStatusField && f.Name == "status" {
+				f.SubResource = true
 			}
 		}
 		m.Fields = fields

--- a/internal/goparser/protobuf.go
+++ b/internal/goparser/protobuf.go
@@ -42,6 +42,7 @@ type ProtobufField struct {
 	GoName          string
 	APIFieldName    string
 	Kind            string
+	SubResource     bool
 	IsMap           bool
 	InvalidProtobuf bool
 	MapKeyKind      string

--- a/k8s.io/api/apps/v1/generated.proto
+++ b/k8s.io/api/apps/v1/generated.proto
@@ -76,7 +76,7 @@ message DaemonSet {
   // Populated by the system.
   // Read-only.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-  optional DaemonSetStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", inline: false }];
+  optional DaemonSetStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", sub_resource: true, inline: false }];
 
   option (dev.f110.kubeproto.kind) = {
   };
@@ -180,7 +180,7 @@ message Deployment {
   // Specification of the desired behavior of the Deployment.
   optional DeploymentSpec spec = 3 [(dev.f110.kubeproto.field) = { go_name: "Spec", api_field_name: "spec", inline: false }];
   // Most recently observed status of the Deployment.
-  optional DeploymentStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", inline: false }];
+  optional DeploymentStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", sub_resource: true, inline: false }];
 
   option (dev.f110.kubeproto.kind) = {
   };
@@ -282,7 +282,7 @@ message ReplicaSet {
   // Populated by the system.
   // Read-only.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-  optional ReplicaSetStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", inline: false }];
+  optional ReplicaSetStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", sub_resource: true, inline: false }];
 
   option (dev.f110.kubeproto.kind) = {
   };
@@ -432,7 +432,7 @@ message StatefulSet {
   optional StatefulSetSpec spec = 3 [(dev.f110.kubeproto.field) = { go_name: "Spec", api_field_name: "spec", inline: false }];
   // Status is the current status of Pods in this StatefulSet. This data
   // may be out of date by some window of time.
-  optional StatefulSetStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", inline: false }];
+  optional StatefulSetStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", sub_resource: true, inline: false }];
 
   option (dev.f110.kubeproto.kind) = {
   };

--- a/k8s.io/api/authentication/v1/generated.proto
+++ b/k8s.io/api/authentication/v1/generated.proto
@@ -30,7 +30,7 @@ message TokenRequest {
   // Spec holds information about the request being evaluated
   TokenRequestSpec spec = 3 [(dev.f110.kubeproto.field) = { go_name: "Spec", api_field_name: "spec", inline: false }];
   // Status is filled in by the server and indicates whether the token can be authenticated.
-  optional TokenRequestStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", inline: false }];
+  optional TokenRequestStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", sub_resource: true, inline: false }];
 
   option (dev.f110.kubeproto.kind) = {
   };
@@ -67,7 +67,7 @@ message TokenReview {
   // Spec holds information about the request being evaluated
   TokenReviewSpec spec = 3 [(dev.f110.kubeproto.field) = { go_name: "Spec", api_field_name: "spec", inline: false }];
   // Status is filled in by the server and indicates whether the request can be authenticated.
-  optional TokenReviewStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", inline: false }];
+  optional TokenReviewStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", sub_resource: true, inline: false }];
 
   option (dev.f110.kubeproto.kind) = {
     scope: SCOPE_CLUSTER

--- a/k8s.io/api/authorization/v1/generated.proto
+++ b/k8s.io/api/authorization/v1/generated.proto
@@ -19,7 +19,7 @@ message LocalSubjectAccessReview {
   // you made the request against.  If empty, it is defaulted.
   SubjectAccessReviewSpec spec = 3 [(dev.f110.kubeproto.field) = { go_name: "Spec", api_field_name: "spec", inline: false }];
   // Status is filled in by the server and indicates whether the request is allowed or not
-  optional SubjectAccessReviewStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", inline: false }];
+  optional SubjectAccessReviewStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", sub_resource: true, inline: false }];
 
   option (dev.f110.kubeproto.kind) = {
   };
@@ -77,7 +77,7 @@ message SelfSubjectAccessReview {
   // Spec holds information about the request being evaluated.  user and groups must be empty
   SelfSubjectAccessReviewSpec spec = 3 [(dev.f110.kubeproto.field) = { go_name: "Spec", api_field_name: "spec", inline: false }];
   // Status is filled in by the server and indicates whether the request is allowed or not
-  optional SubjectAccessReviewStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", inline: false }];
+  optional SubjectAccessReviewStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", sub_resource: true, inline: false }];
 
   option (dev.f110.kubeproto.kind) = {
     scope: SCOPE_CLUSTER
@@ -95,7 +95,7 @@ message SelfSubjectRulesReview {
   // Spec holds information about the request being evaluated.
   SelfSubjectRulesReviewSpec spec = 3 [(dev.f110.kubeproto.field) = { go_name: "Spec", api_field_name: "spec", inline: false }];
   // Status is filled in by the server and indicates the set of actions a user can perform.
-  optional SubjectRulesReviewStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", inline: false }];
+  optional SubjectRulesReviewStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", sub_resource: true, inline: false }];
 
   option (dev.f110.kubeproto.kind) = {
     scope: SCOPE_CLUSTER
@@ -111,7 +111,7 @@ message SubjectAccessReview {
   // Spec holds information about the request being evaluated
   SubjectAccessReviewSpec spec = 3 [(dev.f110.kubeproto.field) = { go_name: "Spec", api_field_name: "spec", inline: false }];
   // Status is filled in by the server and indicates whether the request is allowed or not
-  optional SubjectAccessReviewStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", inline: false }];
+  optional SubjectAccessReviewStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", sub_resource: true, inline: false }];
 
   option (dev.f110.kubeproto.kind) = {
     scope: SCOPE_CLUSTER

--- a/k8s.io/api/autoscaling/v1/generated.proto
+++ b/k8s.io/api/autoscaling/v1/generated.proto
@@ -100,7 +100,7 @@ message HorizontalPodAutoscaler {
   // spec defines the behaviour of autoscaler. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
   optional HorizontalPodAutoscalerSpec spec = 3 [(dev.f110.kubeproto.field) = { go_name: "Spec", api_field_name: "spec", inline: false }];
   // status is the current information about the autoscaler.
-  optional HorizontalPodAutoscalerStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", inline: false }];
+  optional HorizontalPodAutoscalerStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", sub_resource: true, inline: false }];
 
   option (dev.f110.kubeproto.kind) = {
   };
@@ -317,7 +317,7 @@ message Scale {
   // spec defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
   optional ScaleSpec spec = 3 [(dev.f110.kubeproto.field) = { go_name: "Spec", api_field_name: "spec", inline: false }];
   // status is the current status of the scale. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status. Read-only.
-  optional ScaleStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", inline: false }];
+  optional ScaleStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", sub_resource: true, inline: false }];
 
   option (dev.f110.kubeproto.kind) = {
   };

--- a/k8s.io/api/autoscaling/v2/generated.proto
+++ b/k8s.io/api/autoscaling/v2/generated.proto
@@ -117,7 +117,7 @@ message HorizontalPodAutoscaler {
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.
   optional HorizontalPodAutoscalerSpec spec = 3 [(dev.f110.kubeproto.field) = { go_name: "Spec", api_field_name: "spec", inline: false }];
   // status is the current information about the autoscaler.
-  optional HorizontalPodAutoscalerStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", inline: false }];
+  optional HorizontalPodAutoscalerStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", sub_resource: true, inline: false }];
 
   option (dev.f110.kubeproto.kind) = {
   };

--- a/k8s.io/api/batch/v1/generated.proto
+++ b/k8s.io/api/batch/v1/generated.proto
@@ -47,7 +47,7 @@ message CronJob {
   optional CronJobSpec spec = 3 [(dev.f110.kubeproto.field) = { go_name: "Spec", api_field_name: "spec", inline: false }];
   // Current status of a cron job.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-  optional CronJobStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", inline: false }];
+  optional CronJobStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", sub_resource: true, inline: false }];
 
   option (dev.f110.kubeproto.kind) = {
   };
@@ -112,7 +112,7 @@ message Job {
   optional JobSpec spec = 3 [(dev.f110.kubeproto.field) = { go_name: "Spec", api_field_name: "spec", inline: false }];
   // Current status of a job.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-  optional JobStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", inline: false }];
+  optional JobStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", sub_resource: true, inline: false }];
 
   option (dev.f110.kubeproto.kind) = {
   };

--- a/k8s.io/api/certificates/v1/generated.proto
+++ b/k8s.io/api/certificates/v1/generated.proto
@@ -51,7 +51,7 @@ message CertificateSigningRequest {
   CertificateSigningRequestSpec spec = 3 [(dev.f110.kubeproto.field) = { go_name: "Spec", api_field_name: "spec", inline: false }];
   // status contains information about whether the request is approved or denied,
   // and the certificate issued by the signer, or the failure condition indicating signer failure.
-  optional CertificateSigningRequestStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", inline: false }];
+  optional CertificateSigningRequestStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", sub_resource: true, inline: false }];
 
   option (dev.f110.kubeproto.kind) = {
     scope: SCOPE_CLUSTER

--- a/k8s.io/api/core/v1/generated.proto
+++ b/k8s.io/api/core/v1/generated.proto
@@ -1785,7 +1785,7 @@ message Namespace {
   optional NamespaceSpec spec = 3 [(dev.f110.kubeproto.field) = { go_name: "Spec", api_field_name: "spec", inline: false }];
   // Status describes the current status of a Namespace.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-  optional NamespaceStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", inline: false }];
+  optional NamespaceStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", sub_resource: true, inline: false }];
 
   option (dev.f110.kubeproto.kind) = {
     scope: SCOPE_CLUSTER
@@ -1834,7 +1834,7 @@ message Node {
   // Populated by the system.
   // Read-only.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-  optional NodeStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", inline: false }];
+  optional NodeStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", sub_resource: true, inline: false }];
 
   option (dev.f110.kubeproto.kind) = {
     scope: SCOPE_CLUSTER
@@ -2112,7 +2112,7 @@ message PersistentVolume {
   // Populated by the system.
   // Read-only.
   // More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistent-volumes
-  optional PersistentVolumeStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", inline: false }];
+  optional PersistentVolumeStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", sub_resource: true, inline: false }];
 
   option (dev.f110.kubeproto.kind) = {
     scope: SCOPE_CLUSTER
@@ -2126,7 +2126,7 @@ message PersistentVolumeClaim {
   // status represents the current information/status of a persistent volume claim.
   // Read-only.
   // More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
-  optional PersistentVolumeClaimStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", inline: false }];
+  optional PersistentVolumeClaimStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", sub_resource: true, inline: false }];
 
   option (dev.f110.kubeproto.kind) = {
   };
@@ -2397,7 +2397,7 @@ message Pod {
   // Populated by the system.
   // Read-only.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-  optional PodStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", inline: false }];
+  optional PodStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", sub_resource: true, inline: false }];
 
   option (dev.f110.kubeproto.kind) = {
   };
@@ -2999,7 +2999,7 @@ message PodStatusResult {
   // Populated by the system.
   // Read-only.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-  optional PodStatus status = 3 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", inline: false }];
+  optional PodStatus status = 3 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", sub_resource: true, inline: false }];
 
   option (dev.f110.kubeproto.kind) = {
   };
@@ -3249,7 +3249,7 @@ message ReplicationController {
   // Populated by the system.
   // Read-only.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-  optional ReplicationControllerStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", inline: false }];
+  optional ReplicationControllerStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", sub_resource: true, inline: false }];
 
   option (dev.f110.kubeproto.kind) = {
   };
@@ -3339,7 +3339,7 @@ message ResourceQuota {
   optional ResourceQuotaSpec spec = 3 [(dev.f110.kubeproto.field) = { go_name: "Spec", api_field_name: "spec", inline: false }];
   // Status defines the actual enforced quota and its current usage.
   // https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-  optional ResourceQuotaStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", inline: false }];
+  optional ResourceQuotaStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", sub_resource: true, inline: false }];
 
   option (dev.f110.kubeproto.kind) = {
   };
@@ -3670,7 +3670,7 @@ message Service {
   // Populated by the system.
   // Read-only.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-  optional ServiceStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", inline: false }];
+  optional ServiceStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", sub_resource: true, inline: false }];
 
   option (dev.f110.kubeproto.kind) = {
   };

--- a/k8s.io/api/networking/v1/generated.proto
+++ b/k8s.io/api/networking/v1/generated.proto
@@ -81,7 +81,7 @@ message Ingress {
   optional IngressSpec spec = 3 [(dev.f110.kubeproto.field) = { go_name: "Spec", api_field_name: "spec", inline: false }];
   // status is the current state of the Ingress.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-  optional IngressStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", inline: false }];
+  optional IngressStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", sub_resource: true, inline: false }];
 
   option (dev.f110.kubeproto.kind) = {
   };
@@ -284,7 +284,7 @@ message NetworkPolicy {
   optional NetworkPolicySpec spec = 3 [(dev.f110.kubeproto.field) = { go_name: "Spec", api_field_name: "spec", inline: false }];
   // status represents the current state of the NetworkPolicy.
   // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-  optional NetworkPolicyStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", inline: false }];
+  optional NetworkPolicyStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", sub_resource: true, inline: false }];
 
   option (dev.f110.kubeproto.kind) = {
   };

--- a/k8s.io/api/policy/v1/generated.proto
+++ b/k8s.io/api/policy/v1/generated.proto
@@ -29,7 +29,7 @@ message PodDisruptionBudget {
   // Specification of the desired behavior of the PodDisruptionBudget.
   optional PodDisruptionBudgetSpec spec = 3 [(dev.f110.kubeproto.field) = { go_name: "Spec", api_field_name: "spec", inline: false }];
   // Most recently observed status of the PodDisruptionBudget.
-  optional PodDisruptionBudgetStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", inline: false }];
+  optional PodDisruptionBudgetStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", sub_resource: true, inline: false }];
 
   option (dev.f110.kubeproto.kind) = {
   };

--- a/k8s.io/api/storage/v1/generated.proto
+++ b/k8s.io/api/storage/v1/generated.proto
@@ -310,7 +310,7 @@ message VolumeAttachment {
   // status represents status of the VolumeAttachment request.
   // Populated by the entity completing the attach or detach
   // operation, i.e. the external-attacher.
-  optional VolumeAttachmentStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", inline: false }];
+  optional VolumeAttachmentStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", sub_resource: true, inline: false }];
 
   option (dev.f110.kubeproto.kind) = {
     scope: SCOPE_CLUSTER

--- a/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/generated.proto
+++ b/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/generated.proto
@@ -107,7 +107,7 @@ message CustomResourceDefinition {
   // spec describes how the user wants the resources to appear
   CustomResourceDefinitionSpec spec = 3 [(dev.f110.kubeproto.field) = { go_name: "Spec", api_field_name: "spec", inline: false }];
   // status indicates the actual state of the CustomResourceDefinition
-  optional CustomResourceDefinitionStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", inline: false }];
+  optional CustomResourceDefinitionStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", sub_resource: true, inline: false }];
 
   option (dev.f110.kubeproto.kind) = {
     scope: SCOPE_CLUSTER

--- a/sigs.k8s.io/gateway-api/apis/v1alpha2/generated.proto
+++ b/sigs.k8s.io/gateway-api/apis/v1alpha2/generated.proto
@@ -224,7 +224,7 @@ message Gateway {
   // Spec defines the desired state of Gateway.
   GatewaySpec spec = 3 [(dev.f110.kubeproto.field) = { go_name: "Spec", api_field_name: "spec", inline: false }];
   // Status defines the current state of Gateway.
-  optional GatewayStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", inline: false }];
+  optional GatewayStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", sub_resource: true, inline: false }];
 
   option (dev.f110.kubeproto.kind) = {
   };
@@ -243,7 +243,7 @@ message GatewayClass {
   // Spec defines the desired state of GatewayClass.
   GatewayClassSpec spec = 3 [(dev.f110.kubeproto.field) = { go_name: "Spec", api_field_name: "spec", inline: false }];
   // Status defines the current state of GatewayClass.
-  optional GatewayClassStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", inline: false }];
+  optional GatewayClassStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", sub_resource: true, inline: false }];
 
   option (dev.f110.kubeproto.kind) = {
     scope: SCOPE_CLUSTER
@@ -637,7 +637,7 @@ message HTTPRoute {
   // Spec defines the desired state of HTTPRoute.
   HTTPRouteSpec spec = 3 [(dev.f110.kubeproto.field) = { go_name: "Spec", api_field_name: "spec", inline: false }];
   // Status defines the current state of HTTPRoute.
-  optional HTTPRouteStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", inline: false }];
+  optional HTTPRouteStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", sub_resource: true, inline: false }];
 
   option (dev.f110.kubeproto.kind) = {
   };
@@ -1213,7 +1213,7 @@ message TCPRoute {
   // Spec defines the desired state of TCPRoute.
   TCPRouteSpec spec = 3 [(dev.f110.kubeproto.field) = { go_name: "Spec", api_field_name: "spec", inline: false }];
   // Status defines the current state of TCPRoute.
-  optional TCPRouteStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", inline: false }];
+  optional TCPRouteStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", sub_resource: true, inline: false }];
 
   option (dev.f110.kubeproto.kind) = {
   };
@@ -1252,7 +1252,7 @@ message TLSRoute {
   // Spec defines the desired state of TLSRoute.
   TLSRouteSpec spec = 3 [(dev.f110.kubeproto.field) = { go_name: "Spec", api_field_name: "spec", inline: false }];
   // Status defines the current state of TLSRoute.
-  optional TLSRouteStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", inline: false }];
+  optional TLSRouteStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", sub_resource: true, inline: false }];
 
   option (dev.f110.kubeproto.kind) = {
   };
@@ -1322,7 +1322,7 @@ message UDPRoute {
   // Spec defines the desired state of UDPRoute.
   UDPRouteSpec spec = 3 [(dev.f110.kubeproto.field) = { go_name: "Spec", api_field_name: "spec", inline: false }];
   // Status defines the current state of UDPRoute.
-  optional UDPRouteStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", inline: false }];
+  optional UDPRouteStatus status = 4 [(dev.f110.kubeproto.field) = { go_name: "Status", api_field_name: "status", sub_resource: true, inline: false }];
 
   option (dev.f110.kubeproto.kind) = {
   };


### PR DESCRIPTION
gen-go-to-protobuf: Support sub resource update

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/f110/kubeproto/pull/59).
* #60
* __->__ #59